### PR TITLE
V030

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## `v0.3.0`
+
+- upgrade duckdb to `1.4.0`
+
 ## `v0.2.0`
 
 - upgrade duckdb to `1.3.2`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-duckdb"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
   "Jesse Rubin",
   "Ryan Fowler", # via ryfowl's `async-sqlite` crate
@@ -29,15 +29,13 @@ extensions-full = ["duckdb/extensions-full"]
 buildtime_bindgen = ["duckdb/buildtime_bindgen"]
 modern-full = ["duckdb/modern-full"]
 polars = ["duckdb/polars"]
-column_decltype = ["duckdb/column_decltype"]
-extra_check = ["duckdb/extra_check"]
 loadable-extension = ["duckdb/loadable-extension"]
 chrono = ["duckdb/chrono"]
 uuid = ["duckdb/uuid"]
 
 [dependencies]
 crossbeam-channel = { version = "0.5.9" }
-duckdb = { version = "1.3.2" }
+duckdb = { version = "1.4.0" }
 futures-channel = { version = "0.3.29" }
 futures-util = { version = "0.3.29" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ polars = ["duckdb/polars"]
 column_decltype = ["duckdb/column_decltype"]
 extra_check = ["duckdb/extra_check"]
 loadable-extension = ["duckdb/loadable-extension"]
+chrono = ["duckdb/chrono"]
+uuid = ["duckdb/uuid"]
 
 [dependencies]
 crossbeam-channel = { version = "0.5.9" }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -77,7 +77,7 @@ async fn test_config_fn() {
         })
         .await
         .expect("client unable to fetch journal_mode");
-    assert_eq!(mode, "desc");
+    assert_eq!(mode.to_lowercase(), "desc");
 }
 
 async fn test_concurrency() {


### PR DESCRIPTION
Thanks for creating this crate! Small PR to support the latest DuckDB major version, 1.4.0.

I've been using this branch in my own project without issue, though I'm only really creating tables and using the Appender object / API. I verified that the command from `test_config_fn` returns uppercase in the 1.4.0 CLI, so the test change there seems acceptable. I didn't see a mention of that change in the DuckDB release notes though.

The  `extra_check` and `column_decltype` features were removed upstream as part of 1.4.0:

https://github.com/duckdb/duckdb-rs/commit/24d54832a65c6e79ad1301818ffdee4ee3dffa47
https://github.com/duckdb/duckdb-rs/commit/3ae2791f3c66272eba610dcd3165c102bcbfd440

AFAICT, the chrono and uuid features also exist for 1.3.2, so that could be backported to the v0.2 series if you want.